### PR TITLE
Fix incorrect attribute reference in temperature sensor warning log

### DIFF
--- a/custom_components/thermostatvalvecontroller/climate.py
+++ b/custom_components/thermostatvalvecontroller/climate.py
@@ -302,7 +302,7 @@ class ValveControllerClimate(ClimateEntity, RestoreEntity):
         if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             _LOGGER.warning(
                 "Temperature sensor %s is %s, applying emergency valve position",
-                self._sensor_entity_id,
+                self._temp_sensor_entity_id,
                 new_state.state if new_state else "removed",
             )
             self._current_temp = None


### PR DESCRIPTION
## Summary
Fixed a bug in the temperature sensor change handler where an incorrect attribute name was being referenced in the warning log message.

## Key Changes
- Changed `self._sensor_entity_id` to `self._temp_sensor_entity_id` in the warning log call within `_async_sensor_changed()` method
- This ensures the correct temperature sensor entity ID is logged when the sensor becomes unavailable or unknown

## Details
The warning message that gets logged when a temperature sensor is unavailable or removed was referencing a non-existent attribute `_sensor_entity_id` instead of the correct `_temp_sensor_entity_id` attribute. This would have caused an AttributeError or logged an incorrect/empty value. The fix ensures the proper entity ID is included in the log message for better debugging and monitoring.

https://claude.ai/code/session_01HxVaokuUF5TRZdWu6KfVeB